### PR TITLE
fees: skip pointless fee parameter calculation during IBD

### DIFF
--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <policy/fees.h>
 #include <policy/policy.h>
+#include <chain.h>
 #include <txmempool.h>
 #include <uint256.h>
 #include <util/time.h>
@@ -11,6 +12,8 @@
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
+
+extern CBlockIndex* pindexBestHeader;
 
 BOOST_FIXTURE_TEST_SUITE(policyestimator_tests, BasicTestingSetup)
 
@@ -23,6 +26,12 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     CAmount basefee(2000);
     CAmount deltaFee(100);
     std::vector<CAmount> feeV;
+
+    pindexBestHeader = new CBlockIndex();
+
+    // Maximum value of blocknum can be 665
+    pindexBestHeader->nHeight = 665;
+    assert(pindexBestHeader->nHeight);
 
     // Populate vectors of increasing fees
     for (int j = 0; j < 10; j++) {
@@ -178,6 +187,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     for (int i = 2; i < 9; i++) { // At 9, the original estimate was already at the bottom (b/c scale = 2)
         BOOST_CHECK(feeEst.estimateFee(i).GetFeePerK() < origFeeEst[i-1] - deltaFee);
     }
+    delete pindexBestHeader;
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Bitcoin nodes update their [TxConfirmStats](https://github.com/bitcoin/bitcoin/blob/92aad5303b9b96c46015156b5dc96b48e9e7bc76/src/policy/fees.cpp#L57) attributes (eg. `confAvg, failAvg` etc..) whenever they see a new block. However, during IBD, we know our best block height, so we can skip the parameter updates up to a certain height, when we know they are not going to affect fee estimates. 

We can see the max value of decay for parameters is .99931. If we do ([max_decay](https://github.com/bitcoin/bitcoin/blob/92aad5303b9b96c46015156b5dc96b48e9e7bc76/src/policy/fees.h#L151))^6048 which is approximate 0.01, it means, that transactions in blocks older than this height, do not affect the current fee estimates significantly. (i.e ~ Best_Block_Height - [6048](https://github.com/bitcoin/bitcoin/blob/92aad5303b9b96c46015156b5dc96b48e9e7bc76/src/policy/fees.h#L144)).

By skipping these updates we can reduce the computation complexity of fee calculation during IBD significantly: ([block_tree_size](https://github.com/bitcoin/bitcoin/blob/92aad5303b9b96c46015156b5dc96b48e9e7bc76/src/init.cpp#L1688) - 6048)/block_tree_size*100 which is ~ 99%.

I got to know about the functions to optimize by analyzing the profiling data of `bitcoind`. It can be generated via `./configure CC=clang CXX=clang++ CXXFLAGS="-fprofile-instr-generate=bitcoind-%p.profraw`